### PR TITLE
Fix import for Dropdown fieldtype

### DIFF
--- a/services/ImportService.php
+++ b/services/ImportService.php
@@ -454,8 +454,33 @@ class ImportService extends BaseApplicationComponent
                     
                     break;
                     
-                case ImportModel::FieldTypeCheckboxes:
                 case ImportModel::FieldTypeDropdown:
+
+                    //get field settings
+                    $settings = $field->getFieldType()->getSettings();
+
+                    //get field options
+                    $options = $settings->getAttribute('options');
+
+                    // find matching option label
+                    $labelSelected = false;
+                    foreach($options as $option){
+
+                        if($labelSelected){
+                            continue;
+                        }
+
+                        if($data == $option['label']){
+                            $data = $option['value'];
+                            //stop looking after first match
+                            $labelSelected = true;
+                        }
+
+                    }
+
+                    break;
+
+                case ImportModel::FieldTypeCheckboxes:
                 case ImportModel::FieldTypeMultiSelect:
                 case ImportModel::FieldTypeRadioButtons:
                     


### PR DESCRIPTION
Importing data into a dropdown field in Craft 2.2.2591 on PHP 5.6 triggers an array to string exception when saving the updated entry.

Updated the prepForFieldType function to keep dropdown data as a sting, as well as including code which maps the correct field value if the CSV contains dropdown field labels.
