### PR TITLE
Entry authorship improvements

### DIFF
--- a/services/Import_EntryService.php
+++ b/services/Import_EntryService.php
@@ -65,7 +65,14 @@ class Import_EntryService extends BaseApplicationComponent
         // Set author
         $author = Import_ElementModel::HandleAuthor;
         if(isset($fields[$author])) {
-            $element->$author = intval($fields[$author]);
+            if(is_numeric($fields[$author])) {
+                $element->$authorId = intval($fields[$author]);
+            } else {
+                $userModel = craft()->users->getUserByUsernameOrEmail($fields[$author]);
+                if($userModel) {
+                    $element->authorId = $userModel->id;
+                }
+            }
             unset($fields[$author]);
         } else {
             $element->$author = ($element->$author ? $element->$author : (craft()->userSession->getUser() ? craft()->userSession->getUser()->id : 1));


### PR DESCRIPTION
I just used Import for the first time today, and you've done amazing work. Very slick!

Anyway, I noticed that entry imports would fail if I included an "author" column, because the "author" property on EntryModel is read-only. So I switched that to store in authorId instead. And while I was at it I added a lookup to allow the author column to contain a username or email as well as a user id - which are more likely to be exportable from another system.