### PR TITLE
Replace 'sourceId' with 'folderId' criteria when linking an asset field

### DIFF
--- a/services/ImportService.php
+++ b/services/ImportService.php
@@ -400,19 +400,19 @@ class ImportService extends BaseApplicationComponent
                         // Get field settings
                         $settings = $field->getFieldType()->getSettings();
 
-                        // Get source id's for connecting
-                        $sourceIds = array();
-                        $sources = $settings->sources;
-                        if (is_array($sources)) {
-                            foreach ($sources as $source) {
-                                list($type, $id) = explode(':', $source);
-                                $sourceIds[] = $id;
+                        // Get folder id's for connecting
+                        $folderIds = array();
+                        $folders = $settings->sources;
+                        if (is_array($folders)) {
+                            foreach ($folders as $folder) {
+                                list($type, $id) = explode(':', $folder);
+                                $folderIds[] = $id;
                             }
                         }
 
-                        // Find matching element in sources
+                        // Find matching element in folders
                         $criteria = craft()->elements->getCriteria(ElementType::Asset);
-                        $criteria->sourceId = $sourceIds;
+                        $criteria->folderId = $folderIds;
                         $criteria->limit = $settings->limit;
 
                         // Get search strings


### PR DESCRIPTION
This PR is a fix for situations where imported asset fields do not correctly link with the corresponding asset record in the index.

When importing data that includes an asset field, assets will not link correctly if its `sourceId` does not match its `folderId`. This happens because in the case of `AssetsFieldType` elements, the call to `$settings->sources` returns an array of `folderId`s rather than `sourceId`s (see https://github.com/pixelandtonic/Craft-Release/blob/07280af57c5f1463d6305dc4efaf7efa99eb1ce2/app/fieldtypes/AssetsFieldType.php#L339). 

While `folderId` and `sourceId` often coincide—so that assets will get correctly linked much of the time—this is not always the case.