### PR TITLE
Expanded integration with 3rd-party plugins

### DIFF
--- a/services/Import_IntegrationService.php
+++ b/services/Import_IntegrationService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Craft;
+
+/**
+ * Import Integration Service.
+ *
+ * Allows 3rd-party plugins to integrate with Import
+ *
+ * @author    Bob Olde Hampsink <b.oldehampsink@itmundi.nl>
+ * @copyright Copyright (c) 2015, Bob Olde Hampsink
+ * @license   http://buildwithcraft.com/license Craft License Agreement
+ *
+ * @link      http://github.com/boboldehampsink
+ */
+class Import_IntegrationService extends BaseApplicationComponent
+{
+    public $customOptionPaths = array();
+
+    /**
+     * Init
+     */
+    public function init()
+    {
+        // Call hook for all plugins
+        $responses = craft()->plugins->call('registerImportOptionPaths');
+
+        // Loop through responses from each plugin
+        foreach ($responses as $customPaths) {
+
+            // Append custom paths to master list
+            $this->customOptionPaths = array_merge($this->customOptionPaths, $customPaths);
+        }
+    }
+
+    /**
+     * Example usage of "registerImportOptionPaths" hook
+     *
+     * @return array of template paths mapped to fieldtypes
+     */
+    /*
+    public function registerImportOptionPaths()
+    {
+        return array(
+            'MyPlugin_MyFieldType' => 'path/to/option/template',
+        );
+    }
+    */
+}

--- a/templates/types/entry/_map.twig
+++ b/templates/types/entry/_map.twig
@@ -49,7 +49,12 @@
                             <optgroup label="{{ tab.name }}">
                         {% for field in tab.getFields() %}
                             {% set f = field.getField() %}
-                            <option value="{{ f.handle }}"{% if column|lower == f.name|lower or column|lower == f.handle|lower %} selected{% endif %}>{{ f.name }}{% if f.required %} *{% endif %}</option>
+                            {% set customOption = craft.import.customOption(f.type) %}
+                            {% if customOption %}
+                                {% include customOption ignore missing %}
+                            {% else %}
+                                <option value="{{ f.handle }}"{% if column|lower == f.name|lower or column|lower == f.handle|lower %} selected{% endif %}>{{ f.name }}{% if f.required %} *{% endif %}</option>
+                            {% endif %}
                         {% endfor %}
                             </optgroup>
                     {% endfor %}

--- a/variables/ImportVariable.php
+++ b/variables/ImportVariable.php
@@ -76,4 +76,24 @@ class ImportVariable
         // Return the log from a certain history
         return craft()->import_history->showLog($history);
     }
+
+    /**
+     * Get path to fieldtype's custom option template
+     *
+     * @return string
+     */
+    public function customOption($fieldHandle)
+    {
+        // Abbreviate for code legibility
+        $customPaths =& craft()->import_integration->customOptionPaths;
+
+        // If fieldtype has been registered and is not falsey
+        if (array_key_exists($fieldHandle, $customPaths) && $customPaths[$fieldHandle]) {
+
+            // Return specified custom path
+            return $customPaths[$fieldHandle];
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Half of the integration already worked perfectly, using your existing `modifyImportRow` hook.

The other half required the ability to provide **custom `select` option(s) in the `types/entry/_map.twig` template**. In order to do this, I created a `registerImportOptionPaths` hook.

I didn't want to interfere much with your original code, so I split that logic into a new `Import_IntegrationService.php` file. This gives a 3rd party plugin the ability to register a path for a custom template, which would contain only the option(s) to be inserted into your existing `select` menu. You can see where I've added [an example of how this hook would be used](https://github.com/boboldehampsink/import/compare/master...lindseydiloreto:master#diff-389973222c64060e62d920df4b93bd18R37) by a 3rd party plugin. This method allows a plugin to potentially register multiple template paths, in case it has multiple field types.

Lastly, this all required a [new variable](https://github.com/boboldehampsink/import/compare/master...lindseydiloreto:master#diff-7400131bd76447ebcc8b7fde39c5bd1fR85), in order to drop in the custom option(s) exactly where it would be needed.

I tried to add comments to as much of this as possible, so it could be somewhat obvious what is taking place. Please let me know if you have any questions... And if you'd like to see an updated copy of Smart Map which takes advantage of this feature, just let me know and I'll send it over!

Thanks!