### PR TITLE
Allow Add/Update, with criteria from "append"

### DIFF
--- a/services/ImportService.php
+++ b/services/ImportService.php
@@ -114,11 +114,14 @@ class ImportService extends BaseApplicationComponent
         // Set up a model to save according to element type
         $entry = $service->setModel($settings);
 
-        // If unique is non-empty array, we're replacing or deleting
+        // If unique is non-empty array, we may be replacing or deleting
         if (is_array($settings['unique']) && count($settings['unique']) > 1) {
-            $entry = $this->replaceOrDelete($row, $settings, $service, $fields, $entry);
-            if ($entry === null) {
+            $replacedEntry = $this->replaceOrDelete($row, $settings, $service, $fields, $entry);
+
+            if ($replacedEntry === null && $settings['behavior'] == ImportModel::BehaviorDelete) {
                 return;
+            } elseif ($replacedEntry) {
+                $entry = $replacedEntry;
             }
         }
 

--- a/services/ImportService.php
+++ b/services/ImportService.php
@@ -118,7 +118,7 @@ class ImportService extends BaseApplicationComponent
         if (is_array($settings['unique']) && count($settings['unique']) > 1) {
             $replacedEntry = $this->replaceOrDelete($row, $settings, $service, $fields, $entry);
 
-            if ($replacedEntry === null && $settings['behavior'] == ImportModel::BehaviorDelete) {
+            if ($replacedEntry === null && $settings['behavior'] !== ImportModel::BehaviorAppend) {
                 return;
             } elseif ($replacedEntry) {
                 $entry = $replacedEntry;

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -63,7 +63,7 @@
                             <div class="heading">
                                 <label>{{ "Import behavior"|t }}</label>
                                 <div class="instructions">
-                                    <p>{{ "Choose whether to create new records, or update or delete existing data."|t }}</p>
+                                    <p>{{ "Choose whether to add new records, update existing records, or delete records."|t }}</p>
                                 </div>
                             </div>
                         </div>
@@ -73,9 +73,9 @@
                             <div class="input">
                                 <div class="select">
                                     <select name="import[behavior]" id="behaviors">
-                                        {% if currentUser.can('append') %}<option value="append">{{ "Append data"|t }}</option>{% endif %}
-                                        {% if currentUser.can('replace') %}<option value="replace">{{ "Replace data"|t }}</option>{% endif %}
-                                        {% if currentUser.can('delete') %}<option value="delete">{{ "Delete data"|t }}</option>{% endif %}
+                                        {% if currentUser.can('append') %}<option value="append">{{ "Add/Update Records"|t }}</option>{% endif %}
+                                        {% if currentUser.can('replace') %}<option value="replace">{{ "Update Records"|t }}</option>{% endif %}
+                                        {% if currentUser.can('delete') %}<option value="delete">{{ "Delete Records"|t }}</option>{% endif %}
                                     </select>
                                 </div>
                             </div>

--- a/templates/types/category/_map.twig
+++ b/templates/types/category/_map.twig
@@ -1,17 +1,16 @@
 {% set categoryGroup = craft.categoryGroups.getGroupById(import.elementvars.group) %}
 
 <p>{{ 'Choose the destination fields for your imported data. "Title" is always required.'|t }}</p>
-{% if import.behavior != 'append' %}
-<p>{{ 'Select the field(s) to use as match criteria to find existing Categories to replace or delete data.'|t }}</p>
-{% endif %}
+<p>
+  {{ 'Select the field(s) to use as match criteria to find existing Categories to replace or delete data.'|t }}<br>
+  {{ 'If no match criteria is selected, categories will always be created.'|t }}
+</p>
 
 <table class="data">
     <tr>
         <th>{{ "Column name"|t }}</th>
         <th>{{ "Field name"|t }}</th>
-        {% if import.behavior != 'append' %}
         <th>{{ "Use as match criteria"|t }}</th>
-        {% endif %}
     </tr>
 {% for column in columns %}
     {% set column = column|trim %}
@@ -57,7 +56,6 @@
                 </div>
             </div>
         </td>
-        {% if import.behavior != 'append' %}
         <td class="importCriterium">
         {{ forms.checkboxField({
             label: 'Criterium'|t,
@@ -67,10 +65,9 @@
             checked: loop.first or column|lower == 'locale'
         }) }}
         </td>
-        {% endif %}
     </tr>
 {% endfor %}
     <tr>
-        <td colspan="{% if import.behavior != 'append' %}2{% else %}3{% endif %}" style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
+        <td style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
     </tr>
 </table>

--- a/templates/types/entry/_map.twig
+++ b/templates/types/entry/_map.twig
@@ -3,17 +3,15 @@
 <p>{{ 'Choose the destination fields for your imported data. "{title}" is always required.'|t({
     title: entrytypes[0].titleLabel
 }) }}</p>
-{% if import.behavior != 'append' %}
-<p>{{ 'Select the field(s) to use as match criteria to find existing Entries to replace or delete data.'|t }}</p>
-{% endif %}
+<p>{{ 'Select the field(s) to use as match criteria to find existing Entries to replace or delete data.'|t }}<br>
+  {{ 'If no match criteria is selected, entries will always be created.'|t }}
+</p>
 
 <table class="data">
     <tr>
         <th>{{ "Column name"|t }}</th>
         <th>{{ "Field name"|t }}</th>
-        {% if import.behavior != 'append' %}
         <th>{{ "Use as match criteria"|t }}</th>
-        {% endif %}
     </tr>
 {% for column in columns %}
     {% set column = column|trim %}
@@ -66,7 +64,6 @@
                 </div>
             </div>
         </td>
-        {% if import.behavior != 'append' %}
         <td class="importCriterium">
         {{ forms.checkboxField({
             label: 'Criterium'|t,
@@ -76,10 +73,9 @@
             checked: loop.first or column|lower == 'locale'
         }) }}
         </td>
-        {% endif %}
     </tr>
 {% endfor %}
     <tr>
-        <td colspan="{% if import.behavior != 'append' %}2{% else %}3{% endif %}" style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
+        <td style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
     </tr>
 </table>

--- a/templates/types/user/_map.twig
+++ b/templates/types/user/_map.twig
@@ -1,17 +1,15 @@
 {% set fieldLayout = craft.fields.getLayoutByType(import.type) %}
 
 <p>{{ 'Choose the destination fields for your imported data. "Email" is always required.'|t }}</p>
-{% if import.behavior != 'append' %}
-<p>{{ 'Select the field(s) to use as match criteria to find existing Users to replace or delete data.'|t }}</p>
-{% endif %}
+<p>{{ 'Select the field(s) to use as match criteria to find existing Users to replace or delete data.'|t }}<br>
+  {{ 'If no match criteria is selected, users will always be created.'|t }}
+</p>
 
 <table class="data">
     <tr>
         <th>{{ "Column name"|t }}</th>
         <th>{{ "Field name"|t }}</th>
-        {% if import.behavior != 'append' %}
         <th>{{ "Use as match criteria"|t }}</th>
-        {% endif %}
     </tr>
 {% for column in columns %}
     {% set column = column|trim %}
@@ -55,7 +53,6 @@
                 </div>
             </div>
         </td>
-        {% if import.behavior != 'append' %}
         <td class="importCriterium">
         {{ forms.checkboxField({
             label: 'Criterium'|t,
@@ -65,10 +62,9 @@
             checked: loop.first
         }) }}
         </td>
-        {% endif %}
     </tr>
 {% endfor %}
     <tr>
-        <td colspan="{% if import.behavior != 'append' %}2{% else %}3{% endif %}" style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
+        <td style="border-bottom: none"><input type="submit" class="btn submit" value="{{ 'Import'|t }}"></td>
     </tr>
 </table>


### PR DESCRIPTION
Addresses #114.

This is a very small code change, but allows users the functionality to update existing records OR create new ones if no criteria is matched.

Rather than making an entirely new "behavior", I simply added the "criteria match" fields for `append`.
This allows users to always append by selecting no criteria match fields.

Seemingly the more common use case is achieved by selecting a match criteria. In this case if a match is found, the record is updated. If not, a new one is created.

I also attempted to clarify the language used. The "behaviors" now read as:

- Add/Update Records
- Update Records
- Delete Records