### PR TITLE
Don't force an exact match for parents

### DIFF
--- a/services/Import_CategoryService.php
+++ b/services/Import_CategoryService.php
@@ -175,9 +175,7 @@ class Import_CategoryService extends BaseApplicationComponent implements IImport
             // Find matching element
             $criteria = craft()->elements->getCriteria(ElementType::Category);
             $criteria->groupId = $groupId;
-
-            // Exact match
-            $criteria->search = '"'.$data.'"';
+            $criteria->search = $data;
             $parentCategory = $criteria->first();
         }
 

--- a/services/Import_EntryService.php
+++ b/services/Import_EntryService.php
@@ -227,9 +227,7 @@ class Import_EntryService extends BaseApplicationComponent implements IImportEle
             // Find matching element
             $criteria = craft()->elements->getCriteria(ElementType::Entry);
             $criteria->sectionId = $sectionId;
-
-            // Exact match
-            $criteria->search = '"'.$data.'"';
+            $criteria->search = $data;
 
             // Return the first found element for connecting
             if ($criteria->total()) {


### PR DESCRIPTION
When looking for parents (Categories/Structures), you quote the value for an exact match.
However, this makes it impossible to use other "advanced searching", e.g. myField::"someValue".

When importing other relationship fields (Entires), search values are NOT quoted, so this works fine.

Seems like the behavior should be the same.