### PR TITLE
Loosen search syntax for parent matching

### DIFF
--- a/services/Import_EntryService.php
+++ b/services/Import_EntryService.php
@@ -229,7 +229,7 @@ class Import_EntryService extends BaseApplicationComponent implements IImportEle
             $criteria->sectionId = $sectionId;
 
             // Exact match
-            $criteria->search = '"'.$data.'"';
+            $criteria->search = $data;
 
             // Return the first found element for connecting
             if ($criteria->total()) {


### PR DESCRIPTION
https://github.com/boboldehampsink/import/issues/25

I want to be able to use `fieldHandle::"search string"` to match parents. The quotes prevent me from searching in this manner.